### PR TITLE
Add Windows usage scripts and contrib dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ easage pack --source test_data --output output/path.big
 easage extract --source path/to/a.big --output the/directory/to/extract/into/
 ```
 
+See [contrib](https://github.com/Phrohdoh/easage/tree/master/contrib) for more usage suggestions.
+
 ## License
 
 [MIT](LICENSE.md)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,24 @@
+# `contrib`
+
+Contributed examples of how users may use the `easage` library and tools.
+
+---
+
+## `easage-pack.cmd` and `easage-unpack.cmd`
+
+Scripts for drag-and-drop operations in Windows' File Explorer.
+Handles multiple selections of alpha-numeric filenames or folders.
+
+To use simply select some files or folders and drop them on top of the desired `.cmd` script.
+`easage-pack.cmd` will pack your files/folders into the `BIG` format while `easage-unpack.cmd` unpacks selected `BIG`'s.
+A prefix for `easage-pack.cmd` `BIG` output(s) can be configured for your particular mod.
+
+## License
+
+[MIT](LICENSE.md)
+
+## Contributing
+
+Any contribution you intentionally submit for inclusion in the work, as defined
+in the `LICENSE.md` file, shall be licensed as above, and are subject to the
+project's [CLA](https://gist.github.com/Phrohdoh/d402395a3d8c453e4399f7ae345c0d72).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -6,6 +6,8 @@ Contributed examples of how users may use the `easage` library and tools.
 
 ## `easage-pack.cmd` and `easage-unpack.cmd`
 
+![usage](https://user-images.githubusercontent.com/5067989/31890321-9c3b6a04-b7fa-11e7-87e0-037db87b73f2.gif)
+
 Scripts for drag-and-drop operations in Windows' File Explorer.
 Handles multiple selections of alpha-numeric filenames or folders.
 

--- a/contrib/easage-pack.cmd
+++ b/contrib/easage-pack.cmd
@@ -1,0 +1,52 @@
+@echo off
+rem Contributor: Teteros
+rem Non-alphanumeric filenames were untested and might cause problems
+
+title Drag'n'Drop a selection onto this script to pack into BIGs
+rem Usage: Drag'n'Drop files and folders onto easage-pack.cmd
+rem to pack into BIG format files
+rem easage.exe 'pack' archives recursively
+rem i.e sub-directories are also packed
+if not exist easage.exe goto FileMissing
+
+rem Use wmic command to get current date information in YYYYMMDD format
+for /f %%# in ('wMIC Path Win32_LocalTime Get /Format:value') do @for /f %%@ in ("%%#") do @set %%@
+set "curdate=%year%%month%%day%"
+
+rem A prefix can be set for the output big files
+rem e.g. You may remove the date but keep the bangs
+rem
+rem Common sage modding convention:
+rem one '!' for mod release, two '!!' for hotfix/patch
+
+set modname=MOD
+set modver=001
+set "prefix=!%curdate%_%modname%%modver%_"
+set exit_timeout=5
+
+rem Uncomment line below (remove 'rem') to show your prefix and exit
+rem echo %prefix% & pause & exit
+
+:NotPacked
+if (%1) EQU () goto Packed
+echo Packing: "%~nx1" to "%prefix%%~n1.big"
+easage pack --source "%~nx1" --output "%prefix%%~n1.big"
+shift
+goto NotPacked
+
+:Packed
+echo.
+echo Selected files/folders packed into BIGs or you have not selected anything.
+echo.
+echo Exiting in %exit_timeout% seconds...
+timeout %exit_timeout% & exit /b 0
+
+:FileMissing
+echo.
+echo Current Directory is %CD%
+echo You need the easage.exe tool from easage
+echo library in your current directory to use this script.
+echo.
+echo See https://github.com/Phrohdoh/easage
+echo Aborting.
+pause & exit /b 1

--- a/contrib/easage-unpack.cmd
+++ b/contrib/easage-unpack.cmd
@@ -1,0 +1,56 @@
+@echo off
+rem Contributor: Teteros
+rem Non-alphanumeric filenames were untested and might cause problems
+
+title Drag'n'Drop BIG files onto this script file to unpack them
+rem Usage: Drag'n'Drop BIG files onto this script file to unpack them
+rem Each file in your selection is looped until they are unpacked
+rem Unpack folder is determined by the BIG file(s) name or the 'out' var
+if not exist easage.exe goto FileMissing
+
+rem Set ignore_ext to some value e.g. '1'
+rem to disable .big extension checking
+set ignore_ext=
+rem Set out to unpack to a specific folder.
+set out=
+set exit_timeout=5
+
+:NotExtracted
+if (%1) EQU () goto Extracted
+if not defined ignore_ext (
+    if "%~nx1" NEQ "%~n1.big" goto NotBIG
+)
+if defined out (
+    echo Unpacking: "%~nx1" to "%out%"
+    easage extract --source "%~nx1" --output "%out%"
+) else (
+    echo Unpacking: "%~nx1" to "%~n1"
+    easage extract --source "%~nx1" --output "%~n1"
+)
+shift
+goto NotExtracted
+
+:Extracted
+echo.
+echo All BIGs unpacked or you have not selected anything.
+echo.
+echo Exiting in %exit_timeout% seconds...
+timeout %exit_timeout% & exit /b
+:FileMissing
+echo Current Directory is %CD%
+echo You need the easage.exe tool from easage
+echo library in your current directory to use this script.
+echo.
+echo See https://github.com/Phrohdoh/easage
+echo Aborting.
+pause & exit /b 1
+:NotBIG
+echo.
+echo File %~nx1 does not have a .big extension!
+echo.
+echo If you are sure this is a BIG archive
+echo Please rename the extension of %~nx1 to .big or
+echo disable extension checking by setting ignore_ext in the script
+echo.
+echo Aborting.
+pause & exit /b 1


### PR DESCRIPTION
Adds information about the new `contrib` folder of the repo
as well as adding `easage-pack` and `easage-unpack` Windows explorer
helper scripts.

These scripts utilise drag and drop behaviour for quick packing/unpacking of `BIG` files on Windows.
Demo: 
![usage](https://user-images.githubusercontent.com/5067989/31890321-9c3b6a04-b7fa-11e7-87e0-037db87b73f2.gif)
