### PR TITLE
Default to BIGF instead of BIG4 for packing

### DIFF
--- a/src/bin/easage_pack.rs
+++ b/src/bin/easage_pack.rs
@@ -32,5 +32,5 @@ pub fn run(args: &ArgMatches) -> io::Result<()> {
     let output = args.value_of(ARG_NAME_OUTPUT).unwrap();
     let output = PathBuf::from(output);
 
-    easage::pack_directory(&source, &output, Kind::Big4, Some(b"easage0.0.1"))
+    easage::pack_directory(&source, &output, Kind::BigF, Some(b"easage0.0.1"))
 }


### PR DESCRIPTION
Looking at moddb there is a lot more [Zero Hour](http://www.moddb.com/games/cc-generals-zero-hour/mods) mods than [Battle for Middle-earth](http://www.moddb.com/games/battle-for-middle-earth/mods) mods.

Which might suggest ZH is more popular for modding.
(Currently Zero Hour is at 260 total mods and BFME is at 42.)

I suggest changing the default packing format to `BIGF` instead of `BIG4` to reflect that.

Ideally users should be able to change `BIG` format kind to use at runtime rather than at compile time so I opened #9 