### PR TITLE
Add BIG kind option to easage-pack.cmd

### DIFF
--- a/contrib/easage-pack.cmd
+++ b/contrib/easage-pack.cmd
@@ -13,6 +13,9 @@ rem Use wmic command to get current date information in YYYYMMDD format
 for /f %%# in ('wMIC Path Win32_LocalTime Get /Format:value') do @for /f %%@ in ("%%#") do @set %%@
 set "curdate=%year%%month%%day%"
 
+rem Set BIG target to pack for (BIG4 or BIGF)
+set kind=BIGF
+
 rem A prefix can be set for the output big files
 rem e.g. You may remove the date but keep the bangs
 rem
@@ -30,7 +33,7 @@ rem echo %prefix% & pause & exit
 :NotPacked
 if (%1) EQU () goto Packed
 echo Packing: "%~nx1" to "%prefix%%~n1.big"
-easage pack --source "%~nx1" --output "%prefix%%~n1.big"
+easage pack --kind %kind% --source "%~nx1" --output "%prefix%%~n1.big"
 shift
 goto NotPacked
 


### PR DESCRIPTION
16997aba06e2e004de3ded758e4542d670821b3f onwards expects --kind
parameter to be given in `easage pack`

This commit adds this to the wrapper script in `contrib` with `BIGF` as default.