### PR TITLE
Add Appveyor and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+language: rust
+
+env:
+  global:
+    - CRATE_NAME=easage
+    - FEATURES=clap
+    # 'rust:' statements in lint stage also need to be modified
+    - NIGHTLY=nightly-2018-01-01
+    - RUSTFMT=0.3.4
+    - CLIPPY=0.0.177
+
+stages:
+  - name: lint
+    if: tag IS blank
+  - name: test
+    if: tag IS blank
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  fast_finish: true
+  include:
+    - stage: lint
+      rust: nightly-2018-01-01
+      env: rustfmt
+      before_install:
+        - if ! cargo +$NIGHTLY fmt --version | grep -q $RUSTFMT; then travis_wait cargo +$NIGHTLY install rustfmt-nightly --force --vers $RUSTFMT; fi
+      script:
+        - cargo +$NIGHTLY fmt -- --write-mode=diff
+    - stage: lint
+      rust: nightly-2018-01-01
+      env: clippy
+      before_install:
+        - if [[ `cargo +$NIGHTLY clippy -- --version` != $CLIPPY* ]] ; then travis_wait cargo +$NIGHTLY install clippy --force --vers $CLIPPY; fi
+      script:
+        - cargo +$NIGHTLY clippy --features "$FEATURES" -- -D warnings
+    - stage: test
+      script:
+        - cargo test --features "$FEATURES"
+    - stage: deploy
+      env: TARGET=x86_64-unknown-linux-gnu
+      script: sh ci/before_deploy.sh
+      deploy:
+        provider: releases
+        api_key: $GH_DEPLOY_API_KEY
+        file_glob: true
+        file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
+        on:
+          tags: true
+        skip_cleanup: true
+  allow_failures:
+    - rust: nightly-2018-01-01
+
+cache:
+  directories:
+    - $HOME/.cargo
+    - target/debug/deps
+    - target/debug/build
+before_cache:
+    # Make sure all files are readable by "others" for caching
+    - chmod -R a+r $HOME/.cargo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+# Based on the "trust" template v0.1.1
+# https://github.com/japaric/trust/tree/v0.1.1
+
+environment:
+  global:
+    RUST_VERSION: stable
+    CRATE_NAME: easage
+    FEATURES: clap
+    TARGET: x86_64-pc-windows-msvc
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+test_script:
+  # we don't run the "test phase" when doing deploys
+  - if [%APPVEYOR_REPO_TAG%]==[false] (
+      cargo test --features "%FEATURES%" --target %TARGET%
+    )
+
+before_deploy:
+  - cargo rustc --features "%FEATURES%" --target %TARGET% --bin %CRATE_NAME% --release -- -C lto
+  - ps: ci\before_deploy.ps1
+
+deploy:
+  artifact: /.*\.zip/
+  auth_token: "%GH_DEPLOY_API_KEY%"
+  description: ''
+  on:
+    RUST_VERSION: stable
+    appveyor_repo_tag: true
+  provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+branches:
+  only:
+    # Release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
+    - ci-test
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false

--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -1,0 +1,21 @@
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\$($ENV:CRATE_NAME)-$($ENV:APPVEYOR_REPO_TAG_NAME)-$($ENV:TARGET).zip"
+
+Copy-Item "$SRC_DIR\target\$($ENV:TARGET)\release\$($ENV:CRATE_NAME).exe" '.\'
+Copy-Item "$SRC_DIR\contrib\$($ENV:CRATE_NAME)-pack.cmd" '.\'
+Copy-Item "$SRC_DIR\contrib\$($ENV:CRATE_NAME)-unpack.cmd" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,26 @@
+set -ex
+
+main() {
+    local src=$(pwd) \
+          stage=
+
+    case $TRAVIS_OS_NAME in
+        linux)
+            stage=$(mktemp -d)
+            ;;
+    esac
+
+    test -f Cargo.lock || cargo generate-lockfile
+
+    cargo rustc --features "$FEATURES" --target $TARGET --bin $CRATE_NAME --release -- -C lto
+
+    cp target/$TARGET/release/$CRATE_NAME $stage/
+
+    cd $stage
+    XZ_OPT="-9e --threads 0" tar cJf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.xz *
+    cd $src
+
+    rm -rf $stage
+}
+
+main


### PR DESCRIPTION
Closes #1
- [x] Automatically compile all PRs
- [x] Automatically test all PRs
- [x] Automatically deploy native binaries to GitHub when new a tag is pushed
- [x] Linting & tests on non-tagged committs
- [x] Optimized builds only for tagged committs

Windows tests (appveyor) on master only

# How-to updated in [this](https://github.com/Phrohdoh/easage/pull/17#issuecomment-355438617) comment
You no longer need to checkout my branch or commit if using the environment variable way to setup deployment keys.

# Checkout my branch for editing of the CI files

_Deprecated when using [env vars](https://github.com/Phrohdoh/easage/pull/17#issuecomment-355438617)_.

~`git clone --branch ci-ready https://github.com/Teteros/easage easage-ci`~
~`cd easage-ci`~

# Github's Personal Access Token (PAT)

- Create a Personal Access Token (PAT) with `public_repo` scope.

`curl -u 'Phrohdoh' -d '{"scopes":["public_repo"],"note":"easage releases"}' https://api.github.com/authorizations`

(You will be asked for your github password by CURL)

or if you have two-factor auth enabled you need to make one it directly via [settings](https://github.com/settings/tokens) page (instead of using CURL)

Redacted Curl Output:

```json
{
  ...
  "app": {
    "name": "easage releases",
    ...
  },
  "token": "PAT_TOKEN",
  ...
  "scopes": [
    "public_repo"
  ],
  ...
}
```
You need the data value of `token` for setting up CI (i.e `PAT_TOKEN`)

# Appveyor

_Deprecated when using [env vars](https://github.com/Phrohdoh/easage/pull/17#issuecomment-355438617)_.

~[Sign up](https://ci.appveyor.com/signup) for an open-source account and link it to your github profile if you haven't yet.~

~Enable Appveyor on `easage` repo from new [projects](https://ci.appveyor.com/projects/new) page .~

~Take your PAT token you make earlier via curl/github ~
~and use Appveyor's [encrypt](https://ci.appveyor.com/tools/encrypt) page to get the `secure` token.~

~`sed -i 's/CHANGEME/SECURE_TOKEN/' appveyor.yml`~

# Travis CI

_Deprecated when using [env vars](https://github.com/Phrohdoh/easage/pull/17#issuecomment-355438617)_

~-[Sign up](https://travis-ci.org) for an open-source account and link it to your github profile if you haven't yet.~

~Install travis-ci command-line client. (ruby+gem install needed)~

~`gem install travis -v 1.8.8 --no-rdoc --no-ri`~

~Test if `travis` is now in your path,~

~`which travis` if not, it might be in `~/.gem/ruby/2.4.0/bin/travis`~

~While your shell is still on `easage-ci` dir you can run:~
~(Sub in your `PAT_TOKEN` of course!)~

~`sed -i "s|CHANGEME|$(travis encrypt -r Phrohdoh/easage PAT_TOKEN)|" .travis.yml`~

# Commit changes to ci-ready

_Deprecated when using [env vars](https://github.com/Phrohdoh/easage/pull/17#issuecomment-355438617)_

~If all went well,~

~`grep -r "secure:"`~

~should reveal the `secure:` changed for both `.travis.yml` and `appveyor.yml`~

~You can now commit changes to the `ci-ready` branch directly and it should appear on this pull request as as it's linked.~
~I added [ci skip] to the commit message of command below so the initial commit isn't build:~

~`git add {.travis.yml,appveyor.yml}; git commit -m "Changed CI secure tokens [ci skip]"; git push`~

# Badges

You can edit README.md to include badges for [Travis](https://travis-ci.org/Phrohdoh/easage) and [Appveyor](https://ci.appveyor.com/project/Phrohdoh/easage/settings/badges) build statuses.

More badges are available from [shields.io](http://shields.io) if you want to get fancy.
Maybe one that links to releases?

Travis has a button up top which you can click to display a markdown badge, while for appveyor the link should put you directly to badge preferences page.