### PR TITLE
Add CI Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `easage`
 
+[![Build Status](https://travis-ci.org/Phrohdoh/easage.svg?branch=master)](https://travis-ci.org/Phrohdoh/easage) [![Build Status](https://ci.appveyor.com/api/projects/status/github/Phrohdoh/easage?branch=master&svg=true)](https://ci.appveyor.com/project/Phrohdoh/easage) [![GitHub (pre-)release](https://img.shields.io/github/release/Phrohdoh/easage/all.svg)](https://github.com/Phrohdoh/easage/releases)
+
 A library that provides programmatic manipulation of BIG archives.
 
 ---


### PR DESCRIPTION
For Travis/Appveyor builds and link to release (which might happen soon :-)

If you release this library on crates.io, here is what a badge for that would like:
`[![Crates.io](https://img.shields.io/crates/v/easage.svg)](https://crates.io/crates/easage)`

[![Crates.io](https://img.shields.io/crates/v/easage.svg)](https://crates.io/crates/easage)