### PR TITLE
Add powershell to easage-completions.rs

### DIFF
--- a/src/bin/easage_completions.rs
+++ b/src/bin/easage_completions.rs
@@ -10,7 +10,7 @@ pub fn get_command<'a, 'b>() -> App<'a, 'b> {
         .author("Taryn Hill <taryn@phrohdoh.com>")
         .arg(Arg::with_name(ARG_NAME_SHELL)
                 .required(true)
-                .possible_values(&["bash", "fish", "zsh"])
+                .possible_values(&["bash", "fish", "powershell", "zsh"])
                 .help("The shell to generate the script for"))
 }
 


### PR DESCRIPTION
clap-rs [supports](https://github.com/kbknapp/clap-rs/blob/master/src/completions/powershell.rs) powershell completions.

I've tested them and they seem to work.

`$ easage completions powershell >easage-completions.ps1`
`$ pwsh`
```ps1
PS /home/tete/.wine32/drive_c/Program Files/EA Games/easage-tet/target/debug> ./easage-completions.ps1
PS /home/tete/.wine32/drive_c/Program Files/EA Games/easage-tet/target/debug> ./easage pack -
--help          --kind          --order         --output        --source        --strip-prefix  --version       -h              -V
```
  